### PR TITLE
Optimize speed search

### DIFF
--- a/src/main/java/io/moderne/ai/AgentGenerativeModelClient.java
+++ b/src/main/java/io/moderne/ai/AgentGenerativeModelClient.java
@@ -93,7 +93,7 @@ public class AgentGenerativeModelClient {
                 try {
                     Runtime runtime = Runtime.getRuntime();
                     Process proc_server = runtime.exec((new String[]
-                            {"/bin/sh", "-c", pathToLLama + "/server -m " + pathToModel + " --port " + port}));
+                            {"/bin/sh", "-c", pathToLLama + "/server -m " + pathToModel + " --port " + port }));
 
                     EXECUTOR_SERVICE.submit(() -> {
                         new BufferedReader(new InputStreamReader(proc_server.getInputStream())).lines()

--- a/src/main/java/io/moderne/ai/research/FindCodeThatResembles.java
+++ b/src/main/java/io/moderne/ai/research/FindCodeThatResembles.java
@@ -156,8 +156,15 @@ public class FindCodeThatResembles extends ScanningRecipe<FindCodeThatResembles.
 
         return new JavaIsoVisitor<ExecutionContext>() {
             private String extractTypeName(String fullyQualifiedTypeName) {
-                return fullyQualifiedTypeName.replace("<.*>", "")
-                        .substring(fullyQualifiedTypeName.lastIndexOf('.') + 1);
+                // Split around the '<' and '>' while keeping them for re-insertion
+                String[] parts = fullyQualifiedTypeName.split("(<|>)");
+                String outer = parts[0];
+                String inner = parts.length > 1 ? parts[1] : "";
+
+                outer = outer.substring(outer.lastIndexOf('.') + 1);
+                inner = inner.substring(inner.lastIndexOf('.') + 1);
+
+                return inner.isEmpty() ? outer : outer + "<" + inner + ">";
             }
 
             @SuppressWarnings("OptionalOfNullableMisuse")

--- a/src/test/java/io/moderne/ai/research/FindCodeThatResemblesTest.java
+++ b/src/test/java/io/moderne/ai/research/FindCodeThatResemblesTest.java
@@ -151,6 +151,9 @@ class FindCodeThatResemblesTest implements RewriteTest {
           java(
             """
               import kong.unirest.*;
+              import java.util.ArrayList;
+              import java.util.List;
+              
               class Test {
                   void test() {
                     HttpRequestWithBody request = Unirest.post("https://httpbin.org/post")
@@ -164,6 +167,14 @@ class FindCodeThatResemblesTest implements RewriteTest {
                     string.repeat(10);
                     string.replace(" ", "_");
                     string.isEmpty();
+                    string.repeat(10);
+                    string.repeat(1);
+                    
+                    List<String> listStrings = new ArrayList<>(2);
+                    listStrings.add("additional unrelated string");
+        
+                    List<Integer> listIntegers = new ArrayList<>(2);
+                    listIntegers.add(42);
                     
                     String stringHttpBody = returnHttpBody(string);
                     
@@ -176,6 +187,9 @@ class FindCodeThatResemblesTest implements RewriteTest {
               """,
             """
               import kong.unirest.*;
+              import java.util.ArrayList;
+              import java.util.List;
+              
               class Test {
                   void test() {
                     HttpRequestWithBody request = /*~~>*/Unirest.post("https://httpbin.org/post")
@@ -189,6 +203,14 @@ class FindCodeThatResemblesTest implements RewriteTest {
                     string.repeat(10);
                     string.replace(" ", "_");
                     string.isEmpty();
+                    string.repeat(10);
+                    string.repeat(1);
+                    
+                    List<String> listStrings = new ArrayList<>(2);
+                    listStrings.add("additional unrelated string");
+        
+                    List<Integer> listIntegers = new ArrayList<>(2);
+                    listIntegers.add(42);
                     
                     String stringHttpBody = returnHttpBody(string);
                     


### PR DESCRIPTION
Make getting the generic type for the method signatures more resilient (sometimes part of the signature was cutoff). Limiting the context window for the generative model to 1024 to help with speed.